### PR TITLE
Pass default atom to local-storage-atom

### DIFF
--- a/local-storage-atom/src/com/palletops/bakery/local_storage_atom.cljs
+++ b/local-storage-atom/src/com/palletops/bakery/local_storage_atom.cljs
@@ -11,12 +11,11 @@
   "Return a component that is an atom backed by local storage (if supported).
   `default` is used to initialise the atom if it is not already in
   local storage.  The ILifecycle protocol is not implemented."
-  {:sig [[schema/Any schema/Keyword :- (protocol IDeref)]]}
-  [default key]
-  (let [app-state-atom (atom default)]
-    (if js/localStorage
-      (local-storage app-state-atom key)
-      app-state-atom)))
+  {:sig [[(protocol IDeref) schema/Keyword :- (protocol IDeref)]]}
+  [default-atom key]
+  (if js/localStorage
+    (local-storage default-atom key)
+    default-atom))
 
 ;; define a value reference type that is serialised as nil
 (deftype Filtered [v]


### PR DESCRIPTION
Allow use of local-storage-atom with non-core atom implementations, like 
reagent's atom.  This is a breaking change that changes the expected argument
type from a default map to an atom o fthe required type containing the default
values.
